### PR TITLE
fix: update delta on filtering

### DIFF
--- a/src/components/kpi/YouthInYear.jsx
+++ b/src/components/kpi/YouthInYear.jsx
@@ -47,9 +47,7 @@ export function YouthInYear(props) {
   }, [minAge, maxAge, filter]);
 
   useEffect(() => {
-    if (data.length > 1) {
-      setDelta((data[0]?.total_starts / data[1]?.total_starts - 1) * 100);
-    }
+    setDelta((data[0]?.total_starts / data[1]?.total_starts - 1) * 100);
   }, [data]);
 
   return (


### PR DESCRIPTION
This fix' the following bug:
Filter by "Gren" + "Krets" you display number and percentage.
When doing a new filtering and no results are found the old percentage would still be displayed.