### PR TITLE
fix: distance chart error

### DIFF
--- a/src/components/graphs/DistanceChart.jsx
+++ b/src/components/graphs/DistanceChart.jsx
@@ -135,9 +135,10 @@ export function DistanceChart(props) {
             className="h-80"
             data={chartData.map((item) => ({
               period: item.period,
-              ...selectedDistances
-                .map((distance) => ({ [distance]: item[distance][dataPoint] }))
-                .reduce((acc, cur) => ({ ...acc, ...cur }), {}),
+              ...selectedDistances.reduce((acc, distance) => {
+                acc[distance] = item[distance]?.[dataPoint] ?? 0;
+                return acc;
+              }, {}),
             }))}
             index="period"
             autoMinValue={true}


### PR DESCRIPTION
Fixes #4: Handle error when filtering from "Globale filter"
This PR resolves the issue where error occurred reading undefined properties